### PR TITLE
Fixed null pointer during convert amazon purchase

### DIFF
--- a/opfiab-providers/amazon/src/main/java/org/onepf/opfiab/amazon/AmazonUtils.java
+++ b/opfiab-providers/amazon/src/main/java/org/onepf/opfiab/amazon/AmazonUtils.java
@@ -162,7 +162,9 @@ public final class AmazonUtils {
         }
         builder.setToken(receipt.getReceiptId());
         builder.setCanceled(receipt.isCanceled());
-        builder.setPurchaseTime(receipt.getPurchaseDate().getTime());
+        if (receipt.getPurchaseDate() != null) {
+            builder.setPurchaseTime(receipt.getPurchaseDate().getTime());
+        }
         builder.setProviderName(AmazonBillingProvider.NAME);
 
         // Receipt used as a root for originalJson for compatibility purposes


### PR DESCRIPTION
After launch of app with OPFIab library, I've noticed app crashes sometimes, because amazon purchase returns null `purchaseTime`. For more details, see http://crashes.to/s/2a04173b0d9

This PR adds simple null check to address this issue. 
