### PR TITLE
Fix originalJson parsing issue OS<4.4

### DIFF
--- a/opfiab/src/main/java/org/onepf/opfiab/model/JsonModel.java
+++ b/opfiab/src/main/java/org/onepf/opfiab/model/JsonModel.java
@@ -39,9 +39,11 @@ public abstract class JsonModel implements JsonCompatible {
         try {
             final Constructor<E> constructor = clazz.getConstructor(String.class);
             return constructor.newInstance(model.getOriginalJson());
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException
-                | InstantiationException exception) {
-            OPFLog.e("", exception);
+        } catch (Exception e) {
+            // we can't catch separate exceptions here because ReflectiveOperationException
+            // not available on pre KitKat devices
+            // for more info, see https://code.google.com/p/android/issues/detail?id=153406
+            OPFLog.e("Can't create model class from original json", e);
         }
         return null;
     }


### PR DESCRIPTION
We've encountered an issue from some users reports with Amazon store, their receipts couldn't be prepared to verify on our backend (userId value extraction failed).
We can't actually reproduce this issue, as we don't have amazon device with OS<4.4, on 4.4+ all works fine. 
The issue is in this line https://github.com/onepf/OPFIab/blob/dev/opfiab/src/main/java/org/onepf/opfiab/model/JsonModel.java#L42

It's caused by missing `ReflectiveOperationException` class on pre KitKat devices, see https://code.google.com/p/android/issues/detail?id=153406.

This pull request fixes it by rethrowing exceptions to caller and let him handle them instead of silent death.
